### PR TITLE
Add date format settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -422,16 +422,14 @@ class OmnivoreSettingTab extends PluginSettingTab {
     
     new Setting(containerEl)
       .setName("Date Format")
-      .setDesc("Enter the format date for use in rendered template")
-      .addMomentFormat((momentFormat) =>
-      momentFormat
-        .setPlaceholder("Last Sync")
-        .setValue(this.plugin.settings.dateFormat)
-        .setDefaultFormat("yyyy-MM-dd")
-        .onChange(async (value) => {
-          console.log("syncAt: " + value);
-          this.plugin.settings.dateFormat = value;
-          await this.plugin.saveSettings();
+      .setDesc('Enter the format date for use in rendered template')
+      .addText((text) =>
+        text
+          .setPlaceholder("Date Format")
+          .setValue(this.plugin.settings.dateFormat)
+          .onChange(async (value) => {
+            this.plugin.settings.dateFormat = value;
+            await this.plugin.saveSettings();
       })
   );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,6 +273,9 @@ export default class OmnivorePlugin extends Plugin {
 class OmnivoreSettingTab extends PluginSettingTab {
   plugin: OmnivorePlugin;
 
+  private static createFragmentWithHTML = (html: string) =>
+    createFragment((documentFragment) => (documentFragment.createDiv().innerHTML = html));
+
   constructor(app: App, plugin: OmnivorePlugin) {
     super(app, plugin);
     this.plugin = plugin;
@@ -422,7 +425,7 @@ class OmnivoreSettingTab extends PluginSettingTab {
     
     new Setting(containerEl)
       .setName("Date Format")
-      .setDesc('Enter the format date for use in rendered template')
+      .setDesc(OmnivoreSettingTab.createFragmentWithHTML('Enter the format date for use in rendered template.\nFormat <a href="https://moment.github.io/luxon/#/formatting?id=table-of-tokens">reference</a>.'))
       .addText((text) =>
         text
           .setPlaceholder("Date Format")

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,7 +162,7 @@ export default class OmnivorePlugin extends Plugin {
           const siteName =
             article.siteName ||
             this.siteNameFromUrl(article.originalArticleUrl);
-          const dateSaved = new Date(article.savedAt).toString();
+          const dateSaved = DateTime.fromISO(article.savedAt).toFormat(this.settings.dateFormat)
           // Build content string based on template
           let content = Mustache.render(articleTemplate, {
             title: article.title,

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ interface Settings {
   syncing: boolean;
   folder: string;
   intervalId: number;
+  dateFormat: string;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -66,6 +67,7 @@ const DEFAULT_SETTINGS: Settings = {
   syncing: false,
   folder: "Omnivore",
   intervalId: 0,
+  dateFormat: "yyyy-MM-dd"
 };
 
 export default class OmnivorePlugin extends Plugin {
@@ -417,5 +419,20 @@ class OmnivoreSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+    
+    new Setting(containerEl)
+      .setName("Date Format")
+      .setDesc("Enter the format date for use in rendered template")
+      .addMomentFormat((momentFormat) =>
+      momentFormat
+        .setPlaceholder("Last Sync")
+        .setValue(this.plugin.settings.dateFormat)
+        .setDefaultFormat("yyyy-MM-dd")
+        .onChange(async (value) => {
+          console.log("syncAt: " + value);
+          this.plugin.settings.dateFormat = value;
+          await this.plugin.saveSettings();
+      })
+  );
   }
 }


### PR DESCRIPTION
It seems to me that the full date format is not something that everyone wants to see in their notes. For example, just a date is enough for me.
I have added a parameter that will be used by the plugin to display the `dataSaved` field when rendering the template.

P.S. Do not judge strictly, TypeScript as well as JavaScript are not the most familiar languages for me.