### PR TITLE
WIP: render all the frontmatter with the YAML library

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
 		"luxon": "^3.1.1",
 		"markdown-escape": "^2.0.0",
 		"mustache": "^4.2.0",
-		"process": "^0.11.10"
+		"process": "^0.11.10",
+		"yaml": "^2.2.2"
 	},
 	"volta": {
 		"node": "16.15.1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,10 +230,18 @@ export default class OmnivorePlugin extends Plugin {
             article.pageType === PageType.File
               ? await this.downloadFileAsAttachment(article)
               : undefined;
+          const frontMatterItems = [
+            "title",
+            "author",
+            "tags",
+            "date_saved",
+            "date_published",
+          ];
           const content = await renderArticleContnet(
             article,
             template,
             highlightOrder,
+            frontMatterItems,
             this.settings.dateHighlightedFormat,
             this.settings.dateSavedFormat,
             isSingleFile,


### PR DESCRIPTION
This changes how to we render frontmatter to a string, and puts
the entire front matter into a single variable of text that is
created with the YAML library.

Right now we've hard coded the frontMatterItems that are added to
the front matter, but those could be specified as an array in the
settings.
