### PR TITLE
Update template.ts

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -29,7 +29,7 @@ export const DEFAULT_TEMPLATE = `# {{{title}}}
 ## Highlights
 
 {{#highlights}}
-> {{{text}}} [⤴️]({{{highlightUrl}}}) {{#labels}} #{{name}} {{/labels}}
+> {{{text}}} [⤴️]({{{highlightUrl}}}) {{#labels}} #{{name}} {{/labels}} ^{{{highlightID}}}
 {{#note}}
 
 {{{note}}}
@@ -198,7 +198,7 @@ export const renderArticleContnet = async (
     return {
       text: formatHighlightQuote(highlight.quote, template),
       highlightUrl: `https://omnivore.app/me/${article.slug}#${highlight.id}`,
-      highlightID: highlight.id,
+      highlightID: highlight.id.slice(0, 8),
       dateHighlighted: formatDate(highlight.updatedAt, dateHighlightedFormat),
       note: highlight.annotation,
       labels: renderLabels(highlight.labels),


### PR DESCRIPTION
Add functional block-link, using the highlight's ID

The current highlightID cannot be used with Obsidian as-is. Slicing of the part we don't need makes it work. The chance of the same ID in the same document is slim (but this could be solved with adding a counter)