### PR TITLE
Feature: Adding title and labels to the file and folder render

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -135,6 +135,7 @@ export const renderFilename = (
     date,
     dateSaved: date,
     datePublished,
+    labels: article.labels || [],
   });
 
   // truncate the filename to 100 characters
@@ -320,6 +321,8 @@ export const renderFolderName = (
     date,
     dateSaved: date,
     datePublished,
+    labels: article.labels || [],
+    title: article.title,
   });
 };
 


### PR DESCRIPTION
Looks like the settings say you can use title. But you cannot. I also wanted to use the first label to create a subfolder.