### PR TITLE
fix: unescape quote for highlights containing images

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -183,7 +183,7 @@ export const renderArticleContnet = async (
   const highlights: HighlightView[] = articleHighlights.map((highlight) => {
     return {
       text: formatHighlightQuote(highlight.quote, template),
-      unescapeText: unescape(highlight.quote),
+      unescapeText: unescape(highlight.quote || ""),
       highlightUrl: `https://omnivore.app/me/${article.slug}#${highlight.id}`,
       highlightID: highlight.id.slice(0, 8),
       dateHighlighted: formatDate(highlight.updatedAt, dateHighlightedFormat),

--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -1,4 +1,4 @@
-import { truncate } from "lodash";
+import { truncate, unescape } from "lodash";
 import Mustache from "mustache";
 import { parseYaml, stringifyYaml } from "obsidian";
 import { Article, HighlightType, PageType } from "../api";
@@ -183,6 +183,7 @@ export const renderArticleContnet = async (
   const highlights: HighlightView[] = articleHighlights.map((highlight) => {
     return {
       text: formatHighlightQuote(highlight.quote, template),
+      unescapeText: unescape(highlight.quote),
       highlightUrl: `https://omnivore.app/me/${article.slug}#${highlight.id}`,
       highlightID: highlight.id.slice(0, 8),
       dateHighlighted: formatDate(highlight.updatedAt, dateHighlightedFormat),


### PR DESCRIPTION
when highlighting with images, omnivore might escape url, leading uncorrect preview on markdown.
for example,
former preview with {{& text}}:
![former](https://upload.cc/i1/2023/08/21/rgTVI2.png)
now preview with {{& unescapeText}}:
![now](https://upload.cc/i1/2023/08/21/aZfMku.png)