### PR TITLE
fix: add a lambda function in the template to allow users to format date

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -118,10 +118,21 @@ function upperCaseFirst() {
   };
 }
 
+function formatDateFunc() {
+  return function (text: string, render: (text: string) => string) {
+    // get the date and format from the text
+    const [dateVariable, format] = text.split(",", 2);
+    const date = render(dateVariable);
+    // format the date
+    return formatDate(date, format);
+  };
+}
+
 const functionMap: FunctionMap = {
   lowerCase,
   upperCase,
   upperCaseFirst,
+  formatDate: formatDateFunc,
 };
 
 export const renderFilename = (

--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -123,6 +123,9 @@ function formatDateFunc() {
     // get the date and format from the text
     const [dateVariable, format] = text.split(",", 2);
     const date = render(dateVariable);
+    if (!date) {
+      return "";
+    }
     // format the date
     return formatDate(date, format);
   };


### PR DESCRIPTION
added a function `formatDate` to the template which allows users to format a date.

For example, if i want to format `dateArchived` as `yyyy-MM-dd`, I could add following to the template:
```
{{#formatDate}}{{{dateArchived}}},yyyy-MM-dd{{/formatDate}}
```

The `formatDate` lambda takes in a string of the date variable and the format which are separated by a comma.

Fixes #119 