### PR TITLE
Add image to variables list

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -49,6 +49,7 @@ export interface Article {
   content: string
   publishedAt?: string
   url: string
+  image?: string
   readAt?: string
   wordsCount?: number
   readingProgressPercent: number
@@ -112,6 +113,7 @@ export const loadArticles = async (
                   siteName
                   originalArticleUrl
                   url
+                  image
                   author
                   updatedAt
                   description


### PR DESCRIPTION
This lets users set banner images for the articles using the
banners plugin for Obsidian.
