### PR TITLE
Don't sync on startup if frequency is set to 0

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,8 +103,10 @@ export default class OmnivorePlugin extends Plugin {
 
     this.scheduleSync()
 
-    // sync when the app is loaded
-    await this.fetchOmnivore()
+    // sync when the app is loaded if frequency is greater than zero
+    if (this.settings.frequency > 0) {
+      await this.fetchOmnivore()
+    }
   }
 
   onunload() {}


### PR DESCRIPTION
This change has been requested in #174. This change was introduced with no option to toggle it off. This is a hacky workaround until a better solution comes along