### PR TITLE
Reduce number of articles fetched per request

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -240,7 +240,7 @@ export default class OmnivorePlugin extends Plugin {
         (templateSpan) => templateSpan[1] === 'fileAttachment',
       )
 
-      const size = 50
+      const size = 15
       for (
         let hasNextPage = true, articles: Article[] = [], after = 0;
         hasNextPage;


### PR DESCRIPTION
This pull request reduces the number of articles fetched in each request from the Omnivore graphql server. Currently, the number is set to 50. If fetching content is enabled, the graphql server tends to return a 500 server error and causes the plugin to fail to sync articles. This could be a larger problem with the graphql server, but to fix this issue for now, I've lowered the number of articles fetched concurrently to 15. I've tested this PR on my personal Omnivore account.

I believe this is PR resolves #185 and resolves #193. It could be related to #179 as well, but I'm not sure.

If you'd like, I'd also be happy to refactor this change out into a configuration setting (as opposed to just changing the hardcoded value). Let me know if that'd be preferred.