### PR TITLE
Remove comments in single file mode

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -333,11 +333,6 @@ export const renderItemContnet = async (
   let contentWithoutFrontMatter = removeFrontMatterFromContent(content)
   let frontMatterYaml = stringifyYaml(frontMatter)
   if (isSingleFile) {
-    // wrap the content without front matter in comments
-    const sectionStart = `%%${item.id}_start%%`
-    const sectionEnd = `%%${item.id}_end%%`
-    contentWithoutFrontMatter = `${sectionStart}\n${contentWithoutFrontMatter}\n${sectionEnd}`
-
     // if single file, wrap the front matter in an array
     frontMatterYaml = stringifyYaml([frontMatter])
   }


### PR DESCRIPTION
This PR closes https://github.com/omnivore-app/obsidian-omnivore/issues/205

Currently, single file mode inserts comments and line breaks between items. This prevents nicer formatting in single-file mode.

See related issue for an example.