### PR TITLE
Remove illegal characters for folder names too

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -253,8 +253,10 @@ export default class OmnivorePlugin extends Plugin {
         )
 
         for (const item of items) {
-          const folderName = normalizePath(
-            render(item, folder, this.settings.folderDateFormat),
+          const folderName = replaceIllegalChars(
+            normalizePath(
+              render(item, folder, this.settings.folderDateFormat),
+            )
           )
           const omnivoreFolder =
             this.app.vault.getAbstractFileByPath(folderName)


### PR DESCRIPTION
At the moment, we remove illegal characters for file names but not folder names. This diff adds it. 
It will fix a bug that doesn't allow some users from fetching articles when the folder name is illegal. Eg. #207 
