### PR TITLE
Fix for #219 - Folder path separators are incorrectly replaced

### DIFF
--- a/src/__tests__/path_validation.spec.ts
+++ b/src/__tests__/path_validation.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import {
-  ILLEGAL_CHAR_REGEX,
-  replaceIllegalChars,
+  ILLEGAL_CHAR_REGEX_FILE,
+  replaceIllegalCharsFile,
   REPLACEMENT_CHAR,
 } from '../util'
 
@@ -22,56 +22,56 @@ const expectedManualIllegalChars: string[] = [
 // ZERO WIDTH JOINER and SOFT HYPHEN
 const expectedInvisibleChars: string[] = ['­', '‍']
 
-describe('replaceIllegalChars() removes all expected characters', () => {
+describe('replaceIllegalCharsFile() removes all expected characters', () => {
   test.each(expectedManualIllegalChars)(
     'Illegal character "%s" is removed',
     (character) => {
       const input = `this${character}string`
-      const output = replaceIllegalChars(input)
+      const output = replaceIllegalCharsFile(input)
       expect(output).not.toContain(character)
     },
   )
 })
 
-describe('replaceIllegalChars() function replaces illegal characters with replacement char', () => {
+describe('replaceIllegalCharsFile() function replaces illegal characters with replacement char', () => {
   test.each(expectedManualIllegalChars)(
     "Illegal character '%s' is replaced",
     (char) => {
       const input = `this${char}string`
       const expectedOutput = `this${REPLACEMENT_CHAR}string`
-      const output = replaceIllegalChars(input)
+      const output = replaceIllegalCharsFile(input)
       expect(output).toEqual(expectedOutput)
     },
   )
 })
 
-describe('replaceIllegalChars() function does not modify string without illegal characters', () => {
+describe('replaceIllegalCharsFile() function does not modify string without illegal characters', () => {
   test.each(['this_is_a_valid_string', 'this is a valid string'])(
     "String '%s' is not modified",
     (input) => {
-      const output = replaceIllegalChars(input)
+      const output = replaceIllegalCharsFile(input)
       expect(output).toEqual(input)
     },
   )
 })
 
-describe('replaceIllegalChars() function handles empty string', () => {
+describe('replaceIllegalCharsFile() function handles empty string', () => {
   test('Empty string is not modified', () => {
     const input = ''
-    const output = replaceIllegalChars(input)
+    const output = replaceIllegalCharsFile(input)
     expect(output).toEqual(input)
   })
 })
 
-describe('replaceIllegalChars() function replaces all occurrences of illegal characters', () => {
+describe('replaceIllegalCharsFile() function replaces all occurrences of illegal characters', () => {
   test.each(expectedManualIllegalChars)(
     "Illegal character '%s' is replaced",
     (char) => {
       const input = `${char}foo${char}bar`
       const expectedOutput = `${REPLACEMENT_CHAR}foo${REPLACEMENT_CHAR}bar`
-      const output = replaceIllegalChars(input)
+      const output = replaceIllegalCharsFile(input)
       expect(output).toEqual(expectedOutput)
-      expect(output.match(ILLEGAL_CHAR_REGEX)).toBeNull()
+      expect(output.match(ILLEGAL_CHAR_REGEX_FILE)).toBeNull()
     },
   )
 })
@@ -82,7 +82,7 @@ describe('file system behavior with non-alphanumeric characters not in the illeg
     (_, i) => String.fromCharCode(i + 32),
   )
     .filter((char) => !/^[a-zA-Z0-9]+$/.test(char))
-    .map(replaceIllegalChars)
+    .map(replaceIllegalCharsFile)
 
   test.each(nonAlphanumericCharactersWithoutIllegal)(
     "File system allows creation of file with character '%s'",
@@ -101,15 +101,15 @@ describe('file system behavior with non-alphanumeric characters not in the illeg
   )
 })
 
-describe('replaceIllegalChars() function removes all occurrences of invisible characters', () => {
+describe('replaceIllegalCharsFile() function removes all occurrences of invisible characters', () => {
   test.each(expectedInvisibleChars)(
     "Invisible character '%s' is replaced",
     (char) => {
       const input = `${char}foo${char}bar`
       const expectedOutput = 'foobar'
-      const output = replaceIllegalChars(input)
+      const output = replaceIllegalCharsFile(input)
       expect(output).toEqual(expectedOutput)
-      expect(output.match(ILLEGAL_CHAR_REGEX)).toBeNull()
+      expect(output.match(ILLEGAL_CHAR_REGEX_FILE)).toBeNull()
     },
   )
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ import {
   parseDateTime,
   parseFrontMatterFromContent,
   removeFrontMatterFromContent,
-  replaceIllegalChars,
+  replaceIllegalCharsFile,
   setOrUpdateHighlightColors,
 } from './util'
 import { OmnivoreSettingTab } from './settingsTab'
@@ -247,7 +247,7 @@ export default class OmnivorePlugin extends Plugin {
         )
 
         for (const item of items) {
-          const folderName = replaceIllegalChars(
+          const folderName = replaceIllegalCharsFile(
             normalizePath(render(item, folder, this.settings.folderDateFormat)),
           )
           const omnivoreFolder =
@@ -274,7 +274,7 @@ export default class OmnivorePlugin extends Plugin {
             fileAttachment,
           )
           // use the custom filename
-          const customFilename = replaceIllegalChars(
+          const customFilename = replaceIllegalCharsFile(
             renderFilename(item, filename, this.settings.filenameDateFormat),
           )
           const pageName = `${folderName}/${customFilename}.md`

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
   parseFrontMatterFromContent,
   removeFrontMatterFromContent,
   replaceIllegalCharsFile,
+  replaceIllegalCharsFolder,
   setOrUpdateHighlightColors,
 } from './util'
 import { OmnivoreSettingTab } from './settingsTab'
@@ -247,7 +248,7 @@ export default class OmnivorePlugin extends Plugin {
         )
 
         for (const item of items) {
-          const folderName = replaceIllegalCharsFile(
+          const folderName = replaceIllegalCharsFolder(
             normalizePath(render(item, folder, this.settings.folderDateFormat)),
           )
           const omnivoreFolder =

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,8 @@ export const REPLACEMENT_CHAR = '-'
 // On Unix-like systems / is reserved and <>:"/\|?* as well as non-printable characters \u0000-\u001F on Windows
 // credit: https://github.com/sindresorhus/filename-reserved-regex
 // eslint-disable-next-line no-control-regex
-export const ILLEGAL_CHAR_REGEX = /[<>:"/\\|?*\u0000-\u001F]/g
+export const ILLEGAL_CHAR_REGEX_FILE = /[<>:"/\\|?*\u0000-\u001F]/g
+export const ILLEGAL_CHAR_REGEX_FOLDER = /[<>"\\|?*\u0000-\u001F]/g
 
 export interface HighlightPoint {
   left: number
@@ -103,8 +104,12 @@ export const unicodeSlug = (str: string, savedAt: string) => {
   )
 }
 
-export const replaceIllegalChars = (str: string): string => {
-  return removeInvisibleChars(str.replace(ILLEGAL_CHAR_REGEX, REPLACEMENT_CHAR))
+export const replaceIllegalCharsFile = (str: string): string => {
+  return removeInvisibleChars(str.replace(ILLEGAL_CHAR_REGEX_FILE, REPLACEMENT_CHAR))
+}
+
+export const replaceIllegalCharsFolder = (str: string): string => {
+	return removeInvisibleChars(str.replace(ILLEGAL_CHAR_REGEX_FOLDER, REPLACEMENT_CHAR))
 }
 
 export function formatDate(date: string, format: string): string {


### PR DESCRIPTION
The regex for illegal characters of files includes `:` and `/` which are both needed to indicate a new folder on Mac and Win/Linux respectively. Created a separate regex and replacement function for folders where they are removed, so now folders are correctly created when setting the sync and attachment locations.