### PR TITLE
fix: some highlighted markdown content not synced

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -82,7 +82,7 @@ const fetchContentForItems = async (
       item.content = await Promise.race([
         downloadFromUrl(c.downloadUrl),
         new Promise<string>(
-          (_, reject) => setTimeout(() => reject('Timeout'), 60_000), // 60 seconds
+          (_, reject) => setTimeout(() => reject('Timeout'), 600_000), // 10 minutes
         ),
       ])
     }),


### PR DESCRIPTION
* The highlightedMarkdown was not yet uploaded when downloading so we should wait until the uploading to complete
* Increase the download timeout to 10 mins
